### PR TITLE
fix to skip over the DocType element

### DIFF
--- a/link-validator.py
+++ b/link-validator.py
@@ -25,15 +25,18 @@ def validate(url):
 
   wikiUrls = []
   invalidUrls = []
-  for externalUrl in BeautifulSoup(content, parse_only=SoupStrainer('a')):
-    if externalUrl.has_attr('href'):
-      fullExternalUrl = urljoin(url, urldefrag(externalUrl['href']).url)
-      if baseUrl in fullExternalUrl and \
-          not fullExternalUrl.endswith('/_history'):
-        if externalUrl.has_attr('class') and 'absent' in externalUrl['class']:
-          invalidUrls.append(fullExternalUrl)
-        else:
-          wikiUrls.append(fullExternalUrl)
+  # This may see redundant, but without the `.find_all('a')`, soup will also
+  # contain the `DocType` element which does not have an `href` attribute.
+  # See <http://stackoverflow.com/questions/17943992/beautifulsoup-and-soupstrainer-for-getting-links-dont-work-with-hasattr-returni>.
+  soup = BeautifulSoup(content, parse_only=SoupStrainer('a', href=True)).find_all('a')
+  for externalUrl in soup:
+    fullExternalUrl = urljoin(url, urldefrag(externalUrl['href']).url)
+    if baseUrl in fullExternalUrl and \
+        not fullExternalUrl.endswith('/_history'):
+      if externalUrl.has_attr('class') and 'absent' in externalUrl['class']:
+        invalidUrls.append(fullExternalUrl)
+      else:
+        wikiUrls.append(fullExternalUrl)
 
   if len(invalidUrls) > 0:
     invalidWikiPages.append((url, invalidUrls))


### PR DESCRIPTION
The `DocType` element is always returned by bs4, but it does not have an
`href` attribute. This is a quick way to skip over the `DocType` element
and only get `<a>` elements with the `href` attribute.
